### PR TITLE
A few bugfixes

### DIFF
--- a/client.go
+++ b/client.go
@@ -94,7 +94,12 @@ func (c *Client) Create(link string, body, ret interface{}, opts ...CallOption) 
 // Upsert resource
 func (c *Client) Upsert(link string, body, ret interface{}, opts ...CallOption) (*Response, error) {
 	opts = append(opts, Upsert())
-	return c.Create(link, body, ret, opts...)
+	data, err := stringify(body)
+	if err != nil {
+		return nil, err
+	}
+	buf := bytes.NewBuffer(data)
+	return c.method(http.MethodPost, link, http.StatusOK, ret, buf, opts...)
 }
 
 // Replace resource

--- a/options.go
+++ b/options.go
@@ -101,7 +101,7 @@ func SessionToken(sessionToken string) CallOption {
 // CrossPartition allows query to run on all partitions
 func CrossPartition() CallOption {
 	return func(r *Request) error {
-		r.Header.Set(HeaderCrossPartition, "True")
+		r.Header.Set(HeaderCrossPartition, "true")
 		return nil
 	}
 }

--- a/query.go
+++ b/query.go
@@ -9,7 +9,7 @@ type P = Parameter
 
 type Query struct {
 	Query      string      `json:"query"`
-	Parameters []Parameter `json:"parameters"`
+	Parameters []Parameter `json:"parameters,omitempty"`
 }
 
 func NewQuery(query string, parameters ...Parameter) *Query {

--- a/request.go
+++ b/request.go
@@ -23,7 +23,7 @@ const (
 	HeaderContinuation        = "x-ms-continuation"
 	HeaderConsistency         = "x-ms-consistency-level"
 	HeaderSessionToken        = "x-ms-session-token"
-	HeaderCrossPartition      = "x-ms-documentdb-query-enablecrosspartitions"
+	HeaderCrossPartition      = "x-ms-documentdb-query-enablecrosspartition"
 	HeaderIfMatch             = "If-Match"
 	HeaderIfNonMatch          = "If-None-Match"
 	HeaderIfModifiedSince     = "If-Modified-Since"

--- a/request.go
+++ b/request.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -92,7 +93,7 @@ func (req *Request) DefaultHeaders(mKey *Key) (err error) {
 func (req *Request) QueryHeaders(len int) {
 	req.Header.Add(HeaderContentType, "application/query+json")
 	req.Header.Add(HeaderIsQuery, "true")
-	req.Header.Add(HeaderContentLength, string(len))
+	req.Header.Add(HeaderContentLength, strconv.Itoa(len))
 }
 
 func parse(id string) (rId, rType string) {


### PR DESCRIPTION
cc @pavelsmejkal since he might be working on other changes.

Each commit in the pull request is an individual bug fix.

- Content-Length header was corrupted. Probably azure receiving side was tolerant to this optional header.

- Cross-partition query header needed a typo fix to both key and value "True vs true" etc

-  Queries without parameters to documentdb.NewQuery() created a "parameters: null" in the serialized output (azure barfs on it)

- Upsert (POST) to existing document returns 200. This may need further tuning if it optionally returns 200 or 201 . This has been tested with my code.

