### PR TITLE
Add MIT license to LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Ariel Mashraki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ func main() {
 
 ### License
 
-MIT
+Distributed under the MIT license, which is available in the file LICENSE.
 
 [travis-image]: https://img.shields.io/travis/a8m/documentdb.svg?style=flat-square
 [travis-url]: https://travis-ci.org/a8m/documentdb


### PR DESCRIPTION
Hi,

Thanks for a great library! I'd like to use it, however I noticed that there's no license file. Do you mind adding a license file to this repository for the ones that like err on the side of caution? I've added a commit to this PR which does that, but feel free to do it yourself if you prefer that.

The license was copied from https://choosealicense.com/licenses/mit/