### PR TITLE
update header values

### DIFF
--- a/options.go
+++ b/options.go
@@ -10,16 +10,16 @@ type Consistency string
 
 const (
 	// Strong consistency level
-	Strong Consistency = "strong"
+	Strong Consistency = "Strong"
 
 	// Bounded consistency level
-	Bounded Consistency = "bounded"
+	Bounded Consistency = "Bounded"
 
 	// Session consistency level
-	Session Consistency = "session"
+	Session Consistency = "Session"
 
 	// Eventual consistency level
-	Eventual Consistency = "eventual"
+	Eventual Consistency = "Eventual"
 )
 
 // CallOption function


### PR DESCRIPTION
https://docs.microsoft.com/en-us/rest/api/cosmos-db/common-cosmosdb-rest-request-headers. My tests against a newly provisioned CosmosDB database suggest these values are case-sensitive.