### PR TITLE
receive "x-ms-retry-after-ms" field on error 429

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"strconv"
+	"time"
 )
 
 type Clienter interface {
@@ -146,7 +148,18 @@ func (c *Client) do(r *Request, validator statusCodeValidatorFunc, data interfac
 		return nil, err
 	}
 	if !validator(resp.StatusCode) {
-		err = &RequestError{}
+		if resp.StatusCode == 429 {
+			retry := resp.Header.Get("x-ms-retry-after-ms")
+			val, _ := strconv.Atoi(retry)
+			if val == 0 {
+				val = 100
+			}
+			err = &RequestError429{
+				Retry: time.Duration(val) * time.Millisecond,
+			}
+		} else {
+			err = &RequestError{}
+		}
 		readJson(resp.Body, &err)
 		return nil, err
 	}

--- a/request.go
+++ b/request.go
@@ -46,6 +46,18 @@ func (e RequestError) Error() string {
 	return fmt.Sprintf("%v, %v", e.Code, e.Message)
 }
 
+// Request Error
+type RequestError429 struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Retry   time.Duration
+}
+
+// Implement Error function
+func (e RequestError429) Error() string {
+	return fmt.Sprintf("%v, retry after %v", e.Code, e.Retry)
+}
+
 // Resource Request
 type Request struct {
 	rId, rType string


### PR DESCRIPTION
Hi,

I want the x-ms-retry-after-ms value in the HTTP Response Header
when the Cosmos DB returns RequestRateTooLarge (HTTP status code 429) .

so I tried to enhance RequestError{} to RequestError429{} in this pull request.

If you like it, could you use this?