### PR TITLE
feat: add User-Agent and app id

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -78,6 +78,24 @@ func TestRead(t *testing.T) {
 	assert.Equal(err.Error(), "500, DocumentDB error")
 }
 
+func TestReadWithAppIdentifier(t *testing.T) {
+	assert := assert.New(t)
+	s := ServerFactory(`{"_colls": "colls"}`, 500)
+	defer s.Close()
+	client := &Client{Url: s.URL, Config: NewConfig(&Key{Key: "YXJpZWwNCg=="}).WithAppIdentifier("client_test.TestReadWithAppIdentifier")}
+
+	// First call
+	var db Database
+	_, err := client.Read("/dbs/b7NTAS==/", &db)
+	s.AssertHeaders(t, HeaderXDate, HeaderAuth, HeaderVersion, HeaderUserAgent)
+	assert.Equal(db.Colls, "colls", "Should fill the fields from response body")
+	assert.Nil(err, "err should be nil")
+
+	// Second Call, when StatusCode != StatusOK
+	_, err = client.Read("/dbs/b7NCAA==/colls/Ad352/", &db)
+	assert.Equal(err.Error(), "500, DocumentDB error")
+}
+
 func TestQuery(t *testing.T) {
 	assert := assert.New(t)
 	s := ServerFactory(`{"_colls": "colls"}`, 500)

--- a/documentdb.go
+++ b/documentdb.go
@@ -38,6 +38,7 @@ type Config struct {
 	Client                     http.Client
 	IdentificationHydrator     IdentificationHydrator
 	IdentificationPropertyName string
+	AppIdentifier              string
 }
 
 func NewConfig(key *Key) *Config {
@@ -60,6 +61,11 @@ func NewConfigWithServicePrincipal(servicePrincipal ServicePrincipalProvider) *C
 // WithClient stores given http client for later use by documentdb client.
 func (c *Config) WithClient(client http.Client) *Config {
 	c.Client = client
+	return c
+}
+
+func (c *Config) WithAppIdentifier(appIdentifier string) *Config {
+	c.AppIdentifier = appIdentifier
 	return c
 }
 

--- a/documentdb_test.go
+++ b/documentdb_test.go
@@ -252,6 +252,18 @@ func TestCreateDocument(t *testing.T) {
 	assert.NotEqual(t, doc.Id, "")
 }
 
+func TestCreateDocumentWithAppIdentifier(t *testing.T) {
+	client := &ClientStub{}
+	defaultConfig.WithAppIdentifier("documentdb_test.TestCreateDocumentWithAppIdentifier")
+	c := &DocumentDB{client, defaultConfig}
+	// TODO: test error situation, without id, etc...
+	var doc Document
+	client.On("Create", "dbs/colls/docs/", &doc).Return(nil)
+	c.CreateDocument("dbs/colls/", &doc)
+	client.AssertCalled(t, "Create", "dbs/colls/docs/", &doc)
+	assert.NotEqual(t, doc.Id, "")
+}
+
 func TestUpsertDocument(t *testing.T) {
 	client := &ClientStub{}
 	c := &DocumentDB{client, defaultConfig}

--- a/request.go
+++ b/request.go
@@ -31,6 +31,10 @@ const (
 	HeaderRequestCharge       = "x-ms-request-charge"
 	HeaderAIM                 = "A-IM"
 	HeaderPartitionKeyRangeID = "x-ms-documentdb-partitionkeyrangeid"
+	HeaderUserAgent           = "User-Agent"
+
+	ClientName    = "documentdb-go"
+	ClientVersion = "1.3.0"
 
 	SupportedVersion = "2017-02-22"
 )
@@ -63,6 +67,7 @@ func ResourceRequest(link string, req *http.Request) *Request {
 func (req *Request) DefaultHeaders(config *Config) (err error) {
 	req.Header.Add(HeaderXDate, formatDate(time.Now()))
 	req.Header.Add(HeaderVersion, SupportedVersion)
+	req.Header.Add(HeaderUserAgent, strings.Join([]string{ClientName, "/", ClientVersion, " ", config.AppIdentifier}, ""))
 
 	// Authentication via master key
 	if config.MasterKey != nil && config.MasterKey.Key != "" {


### PR DESCRIPTION
## Objective:

Goal of this PR is to add a User-Agent and all for app id to be set. This helps with supportability by Cosmos DB support & some telemetry tooling.

## Changes:
- Added default User-Agent
- Added App Id to Config & helper method to set it
- Tests to cover above added scenarios