### PR TITLE
Allow using a link with IDs and not just RID's + other fixes

### DIFF
--- a/documentdb.go
+++ b/documentdb.go
@@ -27,7 +27,7 @@ var buffers = &sync.Pool{
 	},
 }
 
-var errAAD = errors.New("cannot perform CRUD operations on stored procedures while authenticating with Azure AD")
+var errAAD = errors.New("cannot perform CRUD operations on stored procedures or UDF's while authenticating with Azure AD")
 
 // IdentificationHydrator defines interface for ID hydrators
 // that can prepopulate struct with default values

--- a/documentdb.go
+++ b/documentdb.go
@@ -27,6 +27,8 @@ var buffers = &sync.Pool{
 	},
 }
 
+var errAAD = errors.New("cannot perform CRUD operations on stored procedures while authenticating with Azure AD")
+
 // IdentificationHydrator defines interface for ID hydrators
 // that can prepopulate struct with default values
 type IdentificationHydrator func(config *Config, doc interface{})
@@ -120,7 +122,7 @@ func (c *DocumentDB) ReadDocument(link string, doc interface{}, opts ...CallOpti
 // Read sporc by self link
 func (c *DocumentDB) ReadStoredProcedure(link string, opts ...CallOption) (sproc *Sproc, err error) {
 	if c.usesAAD() {
-		return nil, errors.New("cannot perform CRUD operatons on stored procedures while authenticating with Azure AD")
+		return nil, errAAD
 	}
 
 	_, err = c.client.Read(link, &sproc, opts...)
@@ -133,7 +135,7 @@ func (c *DocumentDB) ReadStoredProcedure(link string, opts ...CallOption) (sproc
 // Read udf by self link
 func (c *DocumentDB) ReadUserDefinedFunction(link string, opts ...CallOption) (udf *UDF, err error) {
 	if c.usesAAD() {
-		return nil, errors.New("cannot perform CRUD operatons on UDFs while authenticating with Azure AD")
+		return nil, errAAD
 	}
 
 	_, err = c.client.Read(link, &udf, opts...)
@@ -156,7 +158,7 @@ func (c *DocumentDB) ReadCollections(db string, opts ...CallOption) (colls []Col
 // Read all sprocs by collection self link
 func (c *DocumentDB) ReadStoredProcedures(coll string, opts ...CallOption) (sprocs []Sproc, err error) {
 	if c.usesAAD() {
-		return nil, errors.New("cannot perform CRUD operatons on stored procedures while authenticating with Azure AD")
+		return nil, errAAD
 	}
 
 	return c.QueryStoredProcedures(coll, nil, opts...)
@@ -165,7 +167,7 @@ func (c *DocumentDB) ReadStoredProcedures(coll string, opts ...CallOption) (spro
 // Read pall udfs by collection self link
 func (c *DocumentDB) ReadUserDefinedFunctions(coll string, opts ...CallOption) (udfs []UDF, err error) {
 	if c.usesAAD() {
-		return nil, errors.New("cannot perform CRUD operatons on UDFs while authenticating with Azure AD")
+		return nil, errAAD
 	}
 
 	return c.QueryUserDefinedFunctions(coll, nil, opts...)
@@ -214,7 +216,7 @@ func (c *DocumentDB) QueryCollections(db string, query *Query, opts ...CallOptio
 // Read all collection `sprocs` that satisfy a query
 func (c *DocumentDB) QueryStoredProcedures(coll string, query *Query, opts ...CallOption) (sprocs []Sproc, err error) {
 	if c.usesAAD() {
-		return nil, errors.New("cannot perform CRUD operatons on stored procedures while authenticating with Azure AD")
+		return nil, errAAD
 	}
 
 	data := struct {
@@ -235,7 +237,7 @@ func (c *DocumentDB) QueryStoredProcedures(coll string, query *Query, opts ...Ca
 // Read all collection `udfs` that satisfy a query
 func (c *DocumentDB) QueryUserDefinedFunctions(coll string, query *Query, opts ...CallOption) (udfs []UDF, err error) {
 	if c.usesAAD() {
-		return nil, errors.New("cannot perform CRUD operatons on UDFs while authenticating with Azure AD")
+		return nil, errAAD
 	}
 
 	data := struct {
@@ -302,7 +304,7 @@ func (c *DocumentDB) CreateCollection(db string, body interface{}, opts ...CallO
 // Create stored procedure
 func (c *DocumentDB) CreateStoredProcedure(coll string, body interface{}, opts ...CallOption) (sproc *Sproc, err error) {
 	if c.usesAAD() {
-		return nil, errors.New("cannot perform CRUD operatons on stored procedures while authenticating with Azure AD")
+		return nil, errAAD
 	}
 
 	_, err = c.client.Create(coll+"sprocs/", body, &sproc, opts...)
@@ -315,7 +317,7 @@ func (c *DocumentDB) CreateStoredProcedure(coll string, body interface{}, opts .
 // Create user defined function
 func (c *DocumentDB) CreateUserDefinedFunction(coll string, body interface{}, opts ...CallOption) (udf *UDF, err error) {
 	if c.usesAAD() {
-		return nil, errors.New("cannot perform CRUD operatons on UDFs while authenticating with Azure AD")
+		return nil, errAAD
 	}
 
 	_, err = c.client.Create(coll+"udfs/", body, &udf, opts...)
@@ -360,7 +362,7 @@ func (c *DocumentDB) DeleteDocument(link string, opts ...CallOption) (*Response,
 // Delete stored procedure
 func (c *DocumentDB) DeleteStoredProcedure(link string, opts ...CallOption) (*Response, error) {
 	if c.usesAAD() {
-		return nil, errors.New("cannot perform CRUD operatons on stored procedures while authenticating with Azure AD")
+		return nil, errAAD
 	}
 
 	return c.client.Delete(link, opts...)
@@ -369,7 +371,7 @@ func (c *DocumentDB) DeleteStoredProcedure(link string, opts ...CallOption) (*Re
 // Delete user defined function
 func (c *DocumentDB) DeleteUserDefinedFunction(link string, opts ...CallOption) (*Response, error) {
 	if c.usesAAD() {
-		return nil, errors.New("cannot perform CRUD operatons on UDFs while authenticating with Azure AD")
+		return nil, errAAD
 	}
 
 	return c.client.Delete(link, opts...)
@@ -392,7 +394,7 @@ func (c *DocumentDB) ReplaceDocument(link string, doc interface{}, opts ...CallO
 // Replace stored procedure
 func (c *DocumentDB) ReplaceStoredProcedure(link string, body interface{}, opts ...CallOption) (sproc *Sproc, err error) {
 	if c.usesAAD() {
-		return nil, errors.New("cannot perform CRUD operatons on stored procedures while authenticating with Azure AD")
+		return nil, errAAD
 	}
 
 	_, err = c.client.Replace(link, body, &sproc, opts...)
@@ -405,7 +407,7 @@ func (c *DocumentDB) ReplaceStoredProcedure(link string, body interface{}, opts 
 // Replace stored procedure
 func (c *DocumentDB) ReplaceUserDefinedFunction(link string, body interface{}, opts ...CallOption) (udf *UDF, err error) {
 	if c.usesAAD() {
-		return nil, errors.New("cannot perform CRUD operatons on UDFs while authenticating with Azure AD")
+		return nil, errAAD
 	}
 
 	_, err = c.client.Replace(link, body, &udf, opts...)

--- a/documentdb.go
+++ b/documentdb.go
@@ -9,6 +9,8 @@ package documentdb
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"net/http"
 	"reflect"
 	"strings"
@@ -117,6 +119,10 @@ func (c *DocumentDB) ReadDocument(link string, doc interface{}, opts ...CallOpti
 
 // Read sporc by self link
 func (c *DocumentDB) ReadStoredProcedure(link string, opts ...CallOption) (sproc *Sproc, err error) {
+	if c.usesAAD() {
+		return nil, errors.New("cannot perform CRUD operatons on stored procedures while authenticating with Azure AD")
+	}
+
 	_, err = c.client.Read(link, &sproc, opts...)
 	if err != nil {
 		return nil, err
@@ -126,6 +132,10 @@ func (c *DocumentDB) ReadStoredProcedure(link string, opts ...CallOption) (sproc
 
 // Read udf by self link
 func (c *DocumentDB) ReadUserDefinedFunction(link string, opts ...CallOption) (udf *UDF, err error) {
+	if c.usesAAD() {
+		return nil, errors.New("cannot perform CRUD operatons on UDFs while authenticating with Azure AD")
+	}
+
 	_, err = c.client.Read(link, &udf, opts...)
 	if err != nil {
 		return nil, err
@@ -145,11 +155,19 @@ func (c *DocumentDB) ReadCollections(db string, opts ...CallOption) (colls []Col
 
 // Read all sprocs by collection self link
 func (c *DocumentDB) ReadStoredProcedures(coll string, opts ...CallOption) (sprocs []Sproc, err error) {
+	if c.usesAAD() {
+		return nil, errors.New("cannot perform CRUD operatons on stored procedures while authenticating with Azure AD")
+	}
+
 	return c.QueryStoredProcedures(coll, nil, opts...)
 }
 
 // Read pall udfs by collection self link
 func (c *DocumentDB) ReadUserDefinedFunctions(coll string, opts ...CallOption) (udfs []UDF, err error) {
+	if c.usesAAD() {
+		return nil, errors.New("cannot perform CRUD operatons on UDFs while authenticating with Azure AD")
+	}
+
 	return c.QueryUserDefinedFunctions(coll, nil, opts...)
 }
 
@@ -195,6 +213,10 @@ func (c *DocumentDB) QueryCollections(db string, query *Query, opts ...CallOptio
 
 // Read all collection `sprocs` that satisfy a query
 func (c *DocumentDB) QueryStoredProcedures(coll string, query *Query, opts ...CallOption) (sprocs []Sproc, err error) {
+	if c.usesAAD() {
+		return nil, errors.New("cannot perform CRUD operatons on stored procedures while authenticating with Azure AD")
+	}
+
 	data := struct {
 		Sprocs []Sproc `json:"StoredProcedures,omitempty"`
 		Count  int     `json:"_count,omitempty"`
@@ -212,6 +234,10 @@ func (c *DocumentDB) QueryStoredProcedures(coll string, query *Query, opts ...Ca
 
 // Read all collection `udfs` that satisfy a query
 func (c *DocumentDB) QueryUserDefinedFunctions(coll string, query *Query, opts ...CallOption) (udfs []UDF, err error) {
+	if c.usesAAD() {
+		return nil, errors.New("cannot perform CRUD operatons on UDFs while authenticating with Azure AD")
+	}
+
 	data := struct {
 		Udfs  []UDF `json:"UserDefinedFunctions,omitempty"`
 		Count int   `json:"_count,omitempty"`
@@ -275,6 +301,10 @@ func (c *DocumentDB) CreateCollection(db string, body interface{}, opts ...CallO
 
 // Create stored procedure
 func (c *DocumentDB) CreateStoredProcedure(coll string, body interface{}, opts ...CallOption) (sproc *Sproc, err error) {
+	if c.usesAAD() {
+		return nil, errors.New("cannot perform CRUD operatons on stored procedures while authenticating with Azure AD")
+	}
+
 	_, err = c.client.Create(coll+"sprocs/", body, &sproc, opts...)
 	if err != nil {
 		return nil, err
@@ -284,6 +314,10 @@ func (c *DocumentDB) CreateStoredProcedure(coll string, body interface{}, opts .
 
 // Create user defined function
 func (c *DocumentDB) CreateUserDefinedFunction(coll string, body interface{}, opts ...CallOption) (udf *UDF, err error) {
+	if c.usesAAD() {
+		return nil, errors.New("cannot perform CRUD operatons on UDFs while authenticating with Azure AD")
+	}
+
 	_, err = c.client.Create(coll+"udfs/", body, &udf, opts...)
 	if err != nil {
 		return nil, err
@@ -325,11 +359,19 @@ func (c *DocumentDB) DeleteDocument(link string, opts ...CallOption) (*Response,
 
 // Delete stored procedure
 func (c *DocumentDB) DeleteStoredProcedure(link string, opts ...CallOption) (*Response, error) {
+	if c.usesAAD() {
+		return nil, errors.New("cannot perform CRUD operatons on stored procedures while authenticating with Azure AD")
+	}
+
 	return c.client.Delete(link, opts...)
 }
 
 // Delete user defined function
 func (c *DocumentDB) DeleteUserDefinedFunction(link string, opts ...CallOption) (*Response, error) {
+	if c.usesAAD() {
+		return nil, errors.New("cannot perform CRUD operatons on UDFs while authenticating with Azure AD")
+	}
+
 	return c.client.Delete(link, opts...)
 }
 
@@ -349,6 +391,10 @@ func (c *DocumentDB) ReplaceDocument(link string, doc interface{}, opts ...CallO
 
 // Replace stored procedure
 func (c *DocumentDB) ReplaceStoredProcedure(link string, body interface{}, opts ...CallOption) (sproc *Sproc, err error) {
+	if c.usesAAD() {
+		return nil, errors.New("cannot perform CRUD operatons on stored procedures while authenticating with Azure AD")
+	}
+
 	_, err = c.client.Replace(link, body, &sproc, opts...)
 	if err != nil {
 		return nil, err
@@ -358,6 +404,10 @@ func (c *DocumentDB) ReplaceStoredProcedure(link string, body interface{}, opts 
 
 // Replace stored procedure
 func (c *DocumentDB) ReplaceUserDefinedFunction(link string, body interface{}, opts ...CallOption) (udf *UDF, err error) {
+	if c.usesAAD() {
+		return nil, errors.New("cannot perform CRUD operatons on UDFs while authenticating with Azure AD")
+	}
+
 	_, err = c.client.Replace(link, body, &udf, opts...)
 	if err != nil {
 		return nil, err
@@ -371,11 +421,16 @@ func (c *DocumentDB) ExecuteStoredProcedure(link string, params, body interface{
 	return
 }
 
+// usesAAD returns true if the client is authenticated with Azure AD
+func (c *DocumentDB) usesAAD() bool {
+	return c.config.ServicePrincipal != nil
+}
+
 // ServicePrincipalProvider is an interface for an object that provides an Azure service principal
 // It's normally used with *adal.ServicePrincipalToken objects from github.com/Azure/go-autorest/autorest/adal
 type ServicePrincipalProvider interface {
-	// EnsureFresh will refresh the token if it will expire within the refresh window. This method is safe for concurrent use.
-	EnsureFresh() error
+	// EnsureFreshWithContext will refresh the token if it will expire within the refresh window (as set by RefreshWithin) and autoRefresh flag is on. This method is safe for concurrent use.
+	EnsureFreshWithContext(ctx context.Context) error
 	// OAuthToken returns the current access token.
 	OAuthToken() string
 }

--- a/request.go
+++ b/request.go
@@ -93,7 +93,7 @@ func (req *Request) DefaultHeaders(config *Config, userAgent string) (err error)
 
 		req.Header.Add(HeaderAuth, url.QueryEscape("type=master&ver=1.0&sig="+sign))
 	} else if config.ServicePrincipal != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), ServicePrincipalRefreshTimeout)
+		ctx, cancel := context.WithTimeout(req.Context(), ServicePrincipalRefreshTimeout)
 		defer cancel()
 		err := config.ServicePrincipal.EnsureFreshWithContext(ctx)
 		if err != nil {

--- a/request.go
+++ b/request.go
@@ -125,12 +125,30 @@ func parse(id string) (rId, rType string) {
 	l := len(parts)
 
 	if l%2 == 0 {
-		rId = parts[l-2]
 		rType = parts[l-3]
 	} else {
-		rId = parts[l-3]
 		rType = parts[l-2]
 	}
+
+	// Check if we're being passed a _self link or a link that uses IDs
+	// If we have a self link, parts[2] should be a 6-byte, base64-encoded string, that is 8 characters long and includes padding ("==")
+	// "=" is not a valid character in a Cosmos DB identifier, so if we notice that (especially in a string that's 8-chars long), we know it's a RID
+	if l > 3 && len(parts[2]) == 8 && parts[2][6:] == "==" {
+		// We have a _self link
+		if l%2 == 0 {
+			rId = parts[l-2]
+		} else {
+			rId = parts[l-3]
+		}
+	} else {
+		// We have a link that uses IDs
+		end := l - 1
+		if l%2 == 1 {
+			end = l - 2
+		}
+		rId = strings.Join(parts[1:end], "/")
+	}
+
 	return
 }
 


### PR DESCRIPTION
This PR includes three changes:

**First**
Currently, all methods accept a "RID link" (i.e. a "self link") only, such as `dbs/9ihLAA==/colls/9ihLANgYXow=/`

Because RIDs are generated within Cosmos DB, we can't always know them beforehand. There are situations (such as some we're encountering in Dapr) where we have no way to retrieve a RID.

This PR changes the authentication routines to allow passing links with IDs too, such as `dbs/dapre2e/colls/items/`.

**Second**

Certain operations are not possible when requests are authenticated using Azure AD, namely CRUD operations on stored procedures and UDFs (however, invoking a SP is always possible). This change returns an error if a user tries to invoke those methods while being auth'd with Azure AD.

**Third**

This is a minor fix, but it changes the way AAD tokens are refreshed, adding a context and a timeout. This is important because if the refresh requests hangs, we want to have a timeout in place (set to 10 seconds, which should be reasonable).

Note that this is _technically_ a breaking change because it changes the `ServicePrincipalProvider` interface. However, that interface was always used to indicate the need for an `*adal.ServicePrincipalToken`, which implements both methods. So in practice (unless users were using this SDK in unexpected ways), nothing should break.

PS: This fixes #29 too