### PR TITLE
Fixed: auth issues when the DB or collection name contained uppercase chars

### DIFF
--- a/request.go
+++ b/request.go
@@ -73,18 +73,18 @@ func (req *Request) DefaultHeaders(config *Config, userAgent string) (err error)
 	if config.MasterKey != nil && config.MasterKey.Key != "" {
 		b := buffers.Get().(*bytes.Buffer)
 		b.Reset()
-		b.WriteString(req.Method)
+		b.WriteString(strings.ToLower(req.Method))
 		b.WriteRune('\n')
-		b.WriteString(req.rType)
+		b.WriteString(strings.ToLower(req.rType))
 		b.WriteRune('\n')
 		b.WriteString(req.rId)
 		b.WriteRune('\n')
-		b.WriteString(req.Header.Get(HeaderXDate))
+		b.WriteString(strings.ToLower(req.Header.Get(HeaderXDate)))
 		b.WriteRune('\n')
-		b.WriteString(req.Header.Get("Date"))
+		b.WriteString(strings.ToLower(req.Header.Get("Date")))
 		b.WriteRune('\n')
 
-		sign, err := authorize(bytes.ToLower(b.Bytes()), config.MasterKey)
+		sign, err := authorize(b.Bytes(), config.MasterKey)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The code that generates signatures using a master key was lower-casing the entire base string (what was going to be signed). However, the `req.Id` part was not supposed to be lower-cased (see the .NET and Node.js [examples in the documentation](https://docs.microsoft.com/en-us/rest/api/cosmos-db/access-control-on-cosmosdb-resources#constructkeytoken)).

Until #36 was merged, this never caused any real-world issues because the library could only be used with `_self` links, where this was never a concern (only part of the link was used and that was always lowercased). However, now that it's possible to pass resource IDs, casing has become important.

A Dapr user reported a regression in the latest nightly builds that was caused by this.

This PR fixes the issue by not lowercasing the `req.Id` part, as per specs.