### PR TITLE
Fixed: when using self links, the rID part must be lowercased

### DIFF
--- a/request.go
+++ b/request.go
@@ -135,10 +135,11 @@ func parse(id string) (rId, rType string) {
 	// "=" is not a valid character in a Cosmos DB identifier, so if we notice that (especially in a string that's 8-chars long), we know it's a RID
 	if l > 3 && len(parts[2]) == 8 && parts[2][6:] == "==" {
 		// We have a _self link
+		// We need to lowercase the part that we extract
 		if l%2 == 0 {
-			rId = parts[l-2]
+			rId = strings.ToLower(parts[l-2])
 		} else {
-			rId = parts[l-3]
+			rId = strings.ToLower(parts[l-3])
 		}
 	} else {
 		// We have a link that uses IDs


### PR DESCRIPTION
#37 fixed an issue by not lowercasing the entire base string to sign, because when using IDs, the ID part must not be lowercased.

However, it seems (and this is [not clearly documented at all](https://docs.microsoft.com/en-us/rest/api/cosmos-db/access-control-on-cosmosdb-resources?redirectedfrom=MSDN#constructkeytoken)) that when using self links, the rID part does have to be lowercased.

This should work for all situations.